### PR TITLE
Fix/homebrew update

### DIFF
--- a/homebrew/files.go
+++ b/homebrew/files.go
@@ -24,6 +24,10 @@ func (p *PackageFile) Basename() string {
 	return filepath.Base(p.GetBrowserDownloadURL())
 }
 
+func (p PackageFile) URL() string {
+	return p.GetURL()
+}
+
 var futures = make(map[PackageFile]func() (string, error))
 
 func (p PackageFile) Sha256() (string, error) {

--- a/homebrew/parse_recipe_test.rb
+++ b/homebrew/parse_recipe_test.rb
@@ -1,29 +1,29 @@
 class Cumulus < Formula
-  desc "Bulk access to multiple AWS clouds"
+  desc "A better AWS (and other cloud) CLI"
   homepage "https://github.com/deweysasser/cumulus"
-  version "v0.2.0"
+  version "v0.5.0"
 
   on_macos do
 
     if Hardware::CPU.intel?
-      url "https://github.com/deweysasser/cumulus/releases/download/v0.2.0/cumulus-darwin-amd64.zip"
-      sha256 "b30c8a75222adb200c26a95707ce2d4eff7680f1fa91a99691f882863ebdb5ff"
+      url "https://github.com/deweysasser/cumulus/releases/download/v0.5.0/cumulus-darwin-amd64.zip"
+      sha256 "d833426e9c5ce8eb7a5acd9a49acb8e31f8ac14ca6f5f3273cadd70a510b5cb8"
     end
 
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/deweysasser/cumulus/releases/download/v0.2.0/cumulus-darwin-arm64.zip"
-      sha256 "4043ff8245ffb2e03af501e652be81a7f9ed939960152b84a4f6734915174650"
+      url "https://github.com/deweysasser/cumulus/releases/download/v0.5.0/cumulus-darwin-arm64.zip"
+      sha256 "c1dea098f6c597392cbd3e90909a15b8e983a428145b2a1bdaf2550723242d7d"
     end
   end
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/deweysasser/cumulus/releases/download/v0.2.0/cumulus-linux-amd64.zip"
-      sha256 "6fccd541dc90d99a4f566d85384d51764d23c8b8b837b3de7769f9e0cf9dbb4f"
+      url "https://github.com/deweysasser/cumulus/releases/download/v0.5.0/cumulus-linux-amd64.zip"
+      sha256 "52ab5e466452c15d4cee4c9d7e8269a8021429b967a30261ad375438b572d8ae"
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/deweysasser/cumulus/releases/download/v0.2.0/cumulus-linux-arm64.zip"
-      sha256 "371744ece3466c097558ad731f96276e1c8446e60507b84534dc35129c459a0a"
+      url "https://github.com/deweysasser/cumulus/releases/download/v0.5.0/cumulus-linux-arm64.zip"
+      sha256 "3195ea54b19f18c1b16d5b35cf815168ac772dc848b5f1efbab506eb972342e0"
     end
   end
 

--- a/homebrew/private_strategy.rb
+++ b/homebrew/private_strategy.rb
@@ -38,7 +38,7 @@
 # strategy is suitable for corporate use just like S3DownloadStrategy, because
 # it lets you use a private GitHub repository for internal distribution.  It
 # works with public one, but in that case simply use CurlDownloadStrategy.
-class GitHubPrivateRepositoryDownloadStrategy < CurlDownloadStrategy
+class GitHubPrivateRepositoryReleaseDownloadStrategy < CurlDownloadStrategy
   require "utils/formatter"
   require "utils/github"
 
@@ -49,21 +49,20 @@ class GitHubPrivateRepositoryDownloadStrategy < CurlDownloadStrategy
   end
 
   def parse_url_pattern
-    unless match = url.match(%r{https://github.com/([^/]+)/([^/]+)/(\S+)})
-      raise CurlDownloadStrategyError, "Invalid url pattern for GitHub Repository."
+    puts "URL:" +String(@url)
+    url_pattern = %r{https://api.github.com/repos/([^/]+)/([^/]+)/releases/assets/(\S+)}
+    unless @url =~ url_pattern
+      raise CurlDownloadStrategyError, "Invalid url pattern for GitHub Release."
     end
 
-    _, @owner, @repo, @filepath = *match
+    _, @owner, @repo, @tag, @filename = *@url.match(url_pattern)
   end
 
-  def download_url
-    "https://#{@github_token}@github.com/#{@owner}/#{@repo}/#{@filepath}"
-  end
 
   private
-
-  def _fetch(url:, resolved_url:, timeout:)
-    curl_download download_url, to: temporary_path
+  def _curl_args
+    args = ["-H", "Accept: application/octet-stream", "-u" "#{@github_token}:x-oauth-basic"]
+    args
   end
 
   def set_github_token
@@ -89,52 +88,3 @@ class GitHubPrivateRepositoryDownloadStrategy < CurlDownloadStrategy
   end
 end
 
-# GitHubPrivateRepositoryReleaseDownloadStrategy downloads tarballs from GitHub
-# Release assets. To use it, add
-# `:using => GitHubPrivateRepositoryReleaseDownloadStrategy` to the URL section of
-# your formula. This download strategy uses GitHub access tokens (in the
-# environment variables HOMEBREW_GITHUB_API_TOKEN) to sign the request.
-class GitHubPrivateRepositoryReleaseDownloadStrategy < GitHubPrivateRepositoryDownloadStrategy
-  def initialize(url, name, version, **meta)
-    super
-  end
-
-  def parse_url_pattern
-    url_pattern = %r{https://github.com/([^/]+)/([^/]+)/releases/download/([^/]+)/(\S+)}
-    unless @url =~ url_pattern
-      raise CurlDownloadStrategyError, "Invalid url pattern for GitHub Release."
-    end
-
-    _, @owner, @repo, @tag, @filename = *@url.match(url_pattern)
-  end
-
-  def download_url
-    "https://#{@github_token}@api.github.com/repos/#{@owner}/#{@repo}/releases/assets/#{asset_id}"
-  end
-
-  private
-
-  def _fetch(url:, resolved_url:, timeout:)
-    # HTTP request header `Accept: application/octet-stream` is required.
-    # Without this, the GitHub API will respond with metadata, not binary.
-    curl_download download_url, "--header", "Accept: application/octet-stream", to: temporary_path
-  end
-
-  def asset_id
-    @asset_id ||= resolve_asset_id
-  end
-
-  def resolve_asset_id
-    release_metadata = fetch_release_metadata
-    assets = release_metadata["assets"].select { |a| a["name"] == @filename }
-    raise CurlDownloadStrategyError, "Asset file not found." if assets.empty?
-
-    assets.first["id"]
-  end
-
-  def fetch_release_metadata
-    #release_url = "https://api.github.com/repos/#{@owner}/#{@repo}/releases/tags/#{@tag}"
-    #GitHub::API.open_rest(release_url)
-    GitHub.get_release(@owner, @repo, @tag)
-  end
-end

--- a/homebrew/recipe.go
+++ b/homebrew/recipe.go
@@ -95,8 +95,9 @@ func (b *Recipe) FillFromGithub() error {
 		log.Debug().
 			Str("name", asset.GetName()).
 			Str("browser_url", asset.GetBrowserDownloadURL()).
-			Str("assert_url", asset.GetURL()).
+			Str("asset_url", asset.GetURL()).
 			Int("size", asset.GetSize()).
+			Bool("isPrivate", b.PrivateRepo).
 			Msg("Found asset")
 		b.Files = append(b.Files, PackageFile{b.PrivateRepo, asset})
 	}

--- a/homebrew/recipe_test.go
+++ b/homebrew/recipe_test.go
@@ -65,7 +65,7 @@ func TestParseRecipeFile(t *testing.T) {
 	current, err := ParseRecipeFile("parse_recipe_test.rb")
 	assert.NoError(t, err)
 
-	assert.Equal(t, "v0.2.0", current.Version)
+	assert.Equal(t, "v0.5.0", current.Version)
 	assert.Equal(t, "Cumulus", current.Repo)
 	//assert.Equal(t, 4, len(current.Files))
 }

--- a/homebrew/template.rb
+++ b/homebrew/template.rb
@@ -15,14 +15,14 @@ class {{.Repo | camelcase}} < Formula
 
     if Hardware::CPU.intel?
       {{ range (files . "darwin" "amd64")  -}}
-     {{if $private}} url "{{.URL}}", :using => GitHubPrivateRepositoryReleaseDownloadStrategy{{else}} url "https://github.com/{{$owner}}/{{$repo}}/releases/download/{{$version}}/{{.Basename}}"{{end}}
+      {{if $private}}url "{{.URL}}", :using => GitHubPrivateRepositoryReleaseDownloadStrategy{{else}}url "https://github.com/{{$owner}}/{{$repo}}/releases/download/{{$version}}/{{.Basename}}"{{end}}
       sha256 "{{.Sha256}}"
       {{- end}}
     end
 
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
       {{ range (files . "darwin" "arm64") -}}
-      {{if $private}} url "{{.URL}}", :using => GitHubPrivateRepositoryReleaseDownloadStrategy{{else}} url "https://github.com/{{$owner}}/{{$repo}}/releases/download/{{$version}}/{{.Basename}}"{{end}}
+      {{if $private}}url "{{.URL}}", :using => GitHubPrivateRepositoryReleaseDownloadStrategy{{else}}url "https://github.com/{{$owner}}/{{$repo}}/releases/download/{{$version}}/{{.Basename}}"{{end}}
       sha256 "{{.Sha256}}"
       {{- end}}
     end
@@ -31,13 +31,13 @@ class {{.Repo | camelcase}} < Formula
   on_linux do
     if Hardware::CPU.intel?
       {{ range (files . "linux" "amd64") -}}
-      {{if $private}} url "{{.URL}}", :using => GitHubPrivateRepositoryReleaseDownloadStrategy{{else}} url "https://github.com/{{$owner}}/{{$repo}}/releases/download/{{$version}}/{{.Basename}}"{{end}}
+      {{if $private}}url "{{.URL}}", :using => GitHubPrivateRepositoryReleaseDownloadStrategy{{else}}url "https://github.com/{{$owner}}/{{$repo}}/releases/download/{{$version}}/{{.Basename}}"{{end}}
       sha256 "{{.Sha256}}"
       {{- end}}
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
       {{ range (files . "linux" "arm64") -}}
-      {{if $private}} url "{{.URL}}", :using => GitHubPrivateRepositoryReleaseDownloadStrategy{{else}} url "https://github.com/{{$owner}}/{{$repo}}/releases/download/{{$version}}/{{.Basename}}"{{end}}
+      {{if $private}}url "{{.URL}}", :using => GitHubPrivateRepositoryReleaseDownloadStrategy{{else}}url "https://github.com/{{$owner}}/{{$repo}}/releases/download/{{$version}}/{{.Basename}}"{{end}}
       sha256 "{{.Sha256}}"
       {{- end}}
     end

--- a/homebrew/template.rb
+++ b/homebrew/template.rb
@@ -15,14 +15,14 @@ class {{.Repo | camelcase}} < Formula
 
     if Hardware::CPU.intel?
       {{ range (files . "darwin" "amd64")  -}}
-      url "https://github.com/{{$owner}}/{{$repo}}/releases/download/{{$version}}/{{.Basename}}"{{if $private}}, :using => GitHubPrivateRepositoryReleaseDownloadStrategy{{end}}
+     {{if $private}} url "{{.URL}}", :using => GitHubPrivateRepositoryReleaseDownloadStrategy{{else}} url "https://github.com/{{$owner}}/{{$repo}}/releases/download/{{$version}}/{{.Basename}}"{{end}}
       sha256 "{{.Sha256}}"
       {{- end}}
     end
 
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
       {{ range (files . "darwin" "arm64") -}}
-      url "https://github.com/{{$owner}}/{{$repo}}/releases/download/{{$version}}/{{.Basename}}"{{if $private}}, :using => GitHubPrivateRepositoryReleaseDownloadStrategy{{end}}
+      {{if $private}} url "{{.URL}}", :using => GitHubPrivateRepositoryReleaseDownloadStrategy{{else}} url "https://github.com/{{$owner}}/{{$repo}}/releases/download/{{$version}}/{{.Basename}}"{{end}}
       sha256 "{{.Sha256}}"
       {{- end}}
     end
@@ -31,13 +31,13 @@ class {{.Repo | camelcase}} < Formula
   on_linux do
     if Hardware::CPU.intel?
       {{ range (files . "linux" "amd64") -}}
-      url "https://github.com/{{$owner}}/{{$repo}}/releases/download/{{$version}}/{{.Basename}}"{{if $private}}, :using => GitHubPrivateRepositoryReleaseDownloadStrategy{{end}}
+      {{if $private}} url "{{.URL}}", :using => GitHubPrivateRepositoryReleaseDownloadStrategy{{else}} url "https://github.com/{{$owner}}/{{$repo}}/releases/download/{{$version}}/{{.Basename}}"{{end}}
       sha256 "{{.Sha256}}"
       {{- end}}
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
       {{ range (files . "linux" "arm64") -}}
-      url "https://github.com/{{$owner}}/{{$repo}}/releases/download/{{$version}}/{{.Basename}}"{{if $private}}, :using => GitHubPrivateRepositoryReleaseDownloadStrategy{{end}}
+      {{if $private}} url "{{.URL}}", :using => GitHubPrivateRepositoryReleaseDownloadStrategy{{else}} url "https://github.com/{{$owner}}/{{$repo}}/releases/download/{{$version}}/{{.Basename}}"{{end}}
       sha256 "{{.Sha256}}"
       {{- end}}
     end


### PR DESCRIPTION
Homebrew 4.0 has introduced changes to the download strategy which break support for downloading files from private repos that require authentication. This update works with the new method, which does not accept redirected URLs.
Since we populate the asset URL now, the private download strategy no longer needs to re-calculate it and has been simplified.