### PR TITLE
feat: generate versioned Homebrew formulas for every release

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,15 @@ A utility for helping make software releases
 Right now this helps me create homebrew recipes for my golang projects by inspecting github and
 generateing recipe files. See [my tap](https://github.com/deweysasser/homebrew-tap) for an example.
 
+For each repo, releasetool writes one Homebrew formula per GitHub release:
+
+- `{repo}.rb` — the **default** formula, pointing at the newest non-prerelease.
+- `{repo}@{version}.rb` — a **versioned** formula per release (including prereleases).
+
+Versioned files are immutable once written; re-running the tool only writes the default when the
+newest stable release has moved. This lets tap users install any historical version or opt into an
+`-rc` build without affecting the default install.
+
 ## Usage
 
 ```shell
@@ -18,6 +27,26 @@ or
 ```shell
 releasetool brew -f repos.yaml
 ```
+
+Installing from the generated tap:
+
+```shell
+brew install deweysasser/tap/cumulus             # newest stable (default)
+brew install deweysasser/tap/cumulus@1.2.0       # a specific stable release
+brew install deweysasser/tap/cumulus@1.2.0-rc1   # opt into a prerelease
+```
+
+## How versions are detected
+
+- **Prerelease flag**: GitHub's `prerelease: true` on a release is authoritative — those releases
+  are emitted as versioned formulas only, never as the default.
+- **Tag-suffix fallback**: tags matching `-rc`, `-alpha`, `-beta`, or `-pre` (case-insensitive) are
+  treated as prereleases even when the flag is not set — both the compact form (`v1.0.0-rc1`) and
+  the semver-dotted form (`v1.0.0-rc.1`, `v1.0.0-alpha.1.2`) are recognized. This is a safety net
+  for repos that tag release candidates without checking the box.
+- **Default selection**: the default unversioned formula points at the newest release that neither
+  rule flags as a prerelease. If a repo has only prereleases, no default formula is written and a
+  warning is logged.
 
 ## The Config file
 

--- a/homebrew/recipe.go
+++ b/homebrew/recipe.go
@@ -27,9 +27,10 @@ type Recipe struct {
 	Description string        `json:"description" yaml:"description"`
 	PrivateRepo bool          `json:"-"`
 	Files       []PackageFile `json:"-"`
-	// ClassName is the Ruby class name used in the rendered formula — either
-	// camelCase(Repo) for the default formula or camelCase(Repo)+"AT"+token
-	// for versioned formulas like "CumulusAT120rc1".
+	// ClassName is the Ruby class name used in the rendered formula. It
+	// must match what Homebrew's Formulary.class_s derives from the
+	// formula's filename (e.g. "cumulus@1.2.0-rc.1.rb" -> CumulusAT120Rc1),
+	// otherwise Homebrew refuses to load the formula.
 	ClassName string `json:"-" yaml:"-"`
 	// OutputFile is the target filename for the generated .rb — "cumulus.rb"
 	// for the default and "cumulus@1.2.0.rb" for versioned formulas.
@@ -177,7 +178,7 @@ func ExpandVersions(base *Recipe, releases []ReleaseInfo) []*Recipe {
 	def.Prerelease = false
 	def.Files = append([]PackageFile(nil), defaultRelease.Files...)
 	def.OutputFile = base.Repo + ".rb"
-	def.ClassName = camelCase(base.Repo)
+	def.ClassName = homebrewClassName(base.Repo)
 	out = append(out, def)
 
 	return out
@@ -297,9 +298,52 @@ func versionFilename(version string) string {
 }
 
 // versionedClass returns the Homebrew versioned-formula class name — e.g.
-// (repo="cumulus", version="v1.2.0-rc1") -> "CumulusAT120rc1".
+// (repo="cumulus", version="v1.2.0-rc.1") -> "CumulusAT120Rc1". It builds
+// the filename stem ("repo@version") and runs it through the class_s
+// transform so the result matches exactly what Homebrew expects when it
+// loads "repo@version.rb".
 func versionedClass(repo, version string) string {
-	return camelCase(repo) + "AT" + tokenWordsOnly(versionFilename(version))
+	return homebrewClassName(repo + "@" + versionFilename(version))
+}
+
+// homebrewSeparatorRE matches Homebrew's class_s separator set
+// (/[-_.\s]([a-zA-Z0-9])/): any hyphen, underscore, dot, or whitespace
+// followed by a single alphanumeric character.
+var homebrewSeparatorRE = regexp.MustCompile(`[-_.\s]([a-zA-Z0-9])`)
+
+// homebrewATRE matches Homebrew's class_s versioned-formula marker
+// (/(.)@(\d)/): any single character, then "@", then a single digit.
+var homebrewATRE = regexp.MustCompile(`(.)@(\d)`)
+
+// homebrewClassName replicates Ruby Homebrew's Formulary.class_s. Matching
+// it exactly is load-bearing: Homebrew derives the expected class name
+// from the .rb filename via this same transform and refuses to load the
+// formula when the class name in the file disagrees.
+//
+// Reference (Library/Homebrew/formulary.rb):
+//
+//	class_name = name.capitalize
+//	class_name.gsub!(/[-_.\s]([a-zA-Z0-9])/) { Regexp.last_match(1).upcase }
+//	class_name.tr!("+", "x")
+//	class_name.sub!(/(.)@(\d)/, '\1AT\2')
+func homebrewClassName(name string) string {
+	if name == "" {
+		return ""
+	}
+	// Ruby's String#capitalize: first char upper, the rest lower.
+	s := strings.ToUpper(name[:1]) + strings.ToLower(name[1:])
+	// Replace each "<sep><alnum>" with the uppercased <alnum>.
+	s = homebrewSeparatorRE.ReplaceAllStringFunc(s, func(m string) string {
+		return strings.ToUpper(m[len(m)-1:])
+	})
+	s = strings.ReplaceAll(s, "+", "x")
+	// Ruby's sub! replaces only the first match; do the same here so a
+	// second "@<digit>" (pathological but legal in a filename) is left
+	// alone.
+	if loc := homebrewATRE.FindStringSubmatchIndex(s); loc != nil {
+		s = s[:loc[0]] + s[loc[2]:loc[3]] + "AT" + s[loc[4]:loc[5]] + s[loc[1]:]
+	}
+	return s
 }
 
 // isPrereleaseTag returns true when a git tag looks like a prerelease by

--- a/homebrew/recipe.go
+++ b/homebrew/recipe.go
@@ -27,6 +27,16 @@ type Recipe struct {
 	Description string        `json:"description" yaml:"description"`
 	PrivateRepo bool          `json:"-"`
 	Files       []PackageFile `json:"-"`
+	// ClassName is the Ruby class name used in the rendered formula — either
+	// camelCase(Repo) for the default formula or camelCase(Repo)+"AT"+token
+	// for versioned formulas like "CumulusAT120rc1".
+	ClassName string `json:"-" yaml:"-"`
+	// OutputFile is the target filename for the generated .rb — "cumulus.rb"
+	// for the default and "cumulus@1.2.0.rb" for versioned formulas.
+	OutputFile string `json:"-" yaml:"-"`
+	// Prerelease is true when this recipe represents a prerelease version
+	// (either GitHub's flag or an -rc/-alpha/-beta/-pre tag).
+	Prerelease bool `json:"-" yaml:"-"`
 }
 
 func NewRecipe(repo, owner, version, description string) (*Recipe, error) {
@@ -64,47 +74,147 @@ var newGithubClient = func() *github.Client {
 	return github.NewClient(githubHttpClient())
 }
 
-func (b *Recipe) FillFromGithub() error {
-	client := newGithubClient()
+// ReleaseInfo is the per-release data returned by FetchReleases: the tag
+// name, whether GitHub (or the tag convention) marks it as a prerelease, and
+// the downloadable assets that a Homebrew formula needs.
+type ReleaseInfo struct {
+	Version    string
+	Prerelease bool
+	Files      []PackageFile
+}
 
-	repo, _, err := client.Repositories.Get(context.Background(), b.Owner, b.Repo)
+// FetchReleases returns every release on the repo by paging through the
+// GitHub ListReleases endpoint until NextPage == 0. The order matches
+// GitHub's response (newest first). Repo description and private-repo
+// detection also happen here so callers only need a single trip.
+func (b *Recipe) FetchReleases() ([]ReleaseInfo, error) {
+	client := newGithubClient()
+	ctx := context.Background()
+
+	repo, _, err := client.Repositories.Get(ctx, b.Owner, b.Repo)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if b.Description == "" {
-		// log.Debug().Str("repo_description", repo.GetDescription()).Msg("Filling with repo description")
 		b.Description = repo.GetDescription()
 	}
-
 	b.PrivateRepo = repo.GetPrivate()
 
-	releases, _, err := client.Repositories.ListReleases(context.Background(), b.Owner, b.Repo, &github.ListOptions{})
+	var all []ReleaseInfo
+	opts := &github.ListOptions{PerPage: 100}
+	for {
+		page, resp, err := client.Repositories.ListReleases(ctx, b.Owner, b.Repo, opts)
+		if err != nil {
+			return nil, err
+		}
+		for _, release := range page {
+			tag := release.GetTagName()
+			log.Debug().Str("tag", tag).Bool("prerelease", release.GetPrerelease()).Msg("Found release")
+			info := ReleaseInfo{
+				Version:    tag,
+				Prerelease: release.GetPrerelease() || isPrereleaseTag(tag),
+			}
+			for _, asset := range release.Assets {
+				log.Debug().
+					Str("name", asset.GetName()).
+					Str("browser_url", asset.GetBrowserDownloadURL()).
+					Str("asset_url", asset.GetURL()).
+					Int("size", asset.GetSize()).
+					Bool("isPrivate", b.PrivateRepo).
+					Msg("Found asset")
+				info.Files = append(info.Files, PackageFile{b.PrivateRepo, asset})
+			}
+			all = append(all, info)
+		}
+		if resp == nil || resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
 
+	return all, nil
+}
+
+// ExpandVersions produces one *Recipe per release plus — when at least one
+// release is non-prerelease — a default unversioned recipe pointing at the
+// newest non-prerelease. Versioned recipes come first in release order
+// (newest first, matching GitHub); the default (if any) is appended last.
+//
+// Each returned recipe has OutputFile, ClassName, Version, Prerelease, and
+// Files set; Owner, Repo, Description, and PrivateRepo are copied from base.
+func ExpandVersions(base *Recipe, releases []ReleaseInfo) []*Recipe {
+	if len(releases) == 0 {
+		return nil
+	}
+
+	out := make([]*Recipe, 0, len(releases)+1)
+
+	var defaultRelease *ReleaseInfo
+	for i, rel := range releases {
+		sub := cloneBase(base)
+		sub.Version = rel.Version
+		sub.Prerelease = rel.Prerelease
+		sub.Files = append([]PackageFile(nil), rel.Files...)
+		sub.OutputFile = base.Repo + "@" + versionFilename(rel.Version) + ".rb"
+		sub.ClassName = versionedClass(base.Repo, rel.Version)
+		out = append(out, sub)
+
+		if defaultRelease == nil && !rel.Prerelease {
+			defaultRelease = &releases[i]
+		}
+	}
+
+	if defaultRelease == nil {
+		log.Warn().
+			Str("repo", base.Repo).
+			Msg("No non-prerelease releases found; skipping default unversioned formula")
+		return out
+	}
+
+	def := cloneBase(base)
+	def.Version = defaultRelease.Version
+	def.Prerelease = false
+	def.Files = append([]PackageFile(nil), defaultRelease.Files...)
+	def.OutputFile = base.Repo + ".rb"
+	def.ClassName = camelCase(base.Repo)
+	out = append(out, def)
+
+	return out
+}
+
+func cloneBase(base *Recipe) *Recipe {
+	return &Recipe{
+		Owner:       base.Owner,
+		Repo:        base.Repo,
+		Description: base.Description,
+		PrivateRepo: base.PrivateRepo,
+	}
+}
+
+// FillFromGithub populates the recipe with the default version — the newest
+// non-prerelease. If the repo has only prereleases, it falls back to the
+// newest release overall so callers that rely on the single-recipe code path
+// still get something to generate.
+func (b *Recipe) FillFromGithub() error {
+	releases, err := b.FetchReleases()
 	if err != nil {
 		return err
 	}
-
 	if len(releases) < 1 {
 		return errors.New("no release found")
 	}
 
-	release := releases[0]
-
-	log.Debug().Str("tag", release.GetTagName()).Msg("Found release")
-
-	// TODO:  if the recipe specifies a release, find it and use that instead
-	b.Version = release.GetTagName()
-	for _, asset := range release.Assets {
-		log.Debug().
-			Str("name", asset.GetName()).
-			Str("browser_url", asset.GetBrowserDownloadURL()).
-			Str("asset_url", asset.GetURL()).
-			Int("size", asset.GetSize()).
-			Bool("isPrivate", b.PrivateRepo).
-			Msg("Found asset")
-		b.Files = append(b.Files, PackageFile{b.PrivateRepo, asset})
+	chosen := releases[0]
+	for _, r := range releases {
+		if !r.Prerelease {
+			chosen = r
+			break
+		}
 	}
+
+	b.Version = chosen.Version
+	b.Files = append(b.Files, chosen.Files...)
 	return nil
 }
 
@@ -163,22 +273,41 @@ func init() {
 }
 
 func (r *Recipe) Generate(output io.Writer) error {
-
-	log.Debug().Str("name", r.Repo).Msg("Generating recipe")
-
-	if len(r.Files) == 0 {
-		log.Debug().Msg("No files given -- fetching from github")
-		if err := r.FillFromGithub(); err != nil {
-			return err
-		}
-	}
-
+	log.Debug().Str("name", r.Repo).Str("version", r.Version).Msg("Generating recipe")
 	return recipeTemplate.Execute(output, r)
 }
 
 // These two must be complimentary sets
 var allowedLetters = regexp.MustCompile("[a-zA-Z0-9_]+")
 var disallowedLetters = regexp.MustCompile("[^a-zA-Z0-9_]")
+
+// prereleaseSuffix matches tag suffixes that indicate a prerelease even when
+// GitHub's own prerelease flag is not set (some repos tag -rc / -beta without
+// checking the box). It anchors to the end of the tag so trailing numeric
+// components like "-rc.2" or "-beta1" still match.
+var prereleaseSuffix = regexp.MustCompile(`(?i)-(rc|alpha|beta|pre)([.\-][a-z0-9]+|[0-9]+)*$`)
+
+// versionFilename strips a single leading "v" or "V" from a tag so it can be
+// used inside a Homebrew versioned-formula filename like "tool@1.2.0.rb".
+func versionFilename(version string) string {
+	if len(version) > 0 && (version[0] == 'v' || version[0] == 'V') {
+		return version[1:]
+	}
+	return version
+}
+
+// versionedClass returns the Homebrew versioned-formula class name — e.g.
+// (repo="cumulus", version="v1.2.0-rc1") -> "CumulusAT120rc1".
+func versionedClass(repo, version string) string {
+	return camelCase(repo) + "AT" + tokenWordsOnly(versionFilename(version))
+}
+
+// isPrereleaseTag returns true when a git tag looks like a prerelease by
+// convention (-rc, -alpha, -beta, -pre, optionally followed by a number or
+// dotted/dashed identifier).
+func isPrereleaseTag(tag string) bool {
+	return prereleaseSuffix.MatchString(tag)
+}
 
 func tokenWordsOnly(s string) string {
 	return disallowedLetters.ReplaceAllString(s, "")

--- a/homebrew/recipe_github_test.go
+++ b/homebrew/recipe_github_test.go
@@ -147,6 +147,206 @@ func TestFillFromGithub_RepoNotFound(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestFetchReleases_PaginatesAllPages(t *testing.T) {
+	mux := http.NewServeMux()
+	server := mockGithub(t, mux)
+
+	mux.HandleFunc("/repos/o/r", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{}`)
+	})
+	mux.HandleFunc("/repos/o/r/releases", func(w http.ResponseWriter, r *http.Request) {
+		page := r.URL.Query().Get("page")
+		switch page {
+		case "", "1":
+			// First page signals a next page via the Link header; this is how
+			// go-github populates resp.NextPage.
+			w.Header().Set("Link", fmt.Sprintf(`<%s/repos/o/r/releases?page=2>; rel="next"`, server.URL))
+			fmt.Fprint(w, `[
+				{"tag_name": "v1.2.0", "assets": [{"name": "tool-linux-amd64.zip", "url": "u1", "browser_download_url": "d1"}]},
+				{"tag_name": "v1.1.0", "assets": []}
+			]`)
+		case "2":
+			fmt.Fprint(w, `[{"tag_name": "v1.0.0", "assets": []}]`)
+		default:
+			t.Fatalf("unexpected page %q", page)
+		}
+	})
+
+	rec := &Recipe{Owner: "o", Repo: "r"}
+	releases, err := rec.FetchReleases()
+	require.NoError(t, err)
+	require.Len(t, releases, 3, "all pages must be collected")
+	assert.Equal(t, "v1.2.0", releases[0].Version)
+	assert.Equal(t, "v1.1.0", releases[1].Version)
+	assert.Equal(t, "v1.0.0", releases[2].Version)
+	// Assets attach to the right release.
+	require.Len(t, releases[0].Files, 1)
+	assert.Equal(t, "tool-linux-amd64.zip", releases[0].Files[0].GetName())
+}
+
+func TestFetchReleases_ReturnsPrereleaseFlag(t *testing.T) {
+	mux := http.NewServeMux()
+	mockGithub(t, mux)
+
+	mux.HandleFunc("/repos/o/r", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{}`)
+	})
+	mux.HandleFunc("/repos/o/r/releases", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `[
+			{"tag_name": "v2.0.0", "prerelease": false, "assets": []},
+			{"tag_name": "v1.5.0", "prerelease": true,  "assets": []}
+		]`)
+	})
+
+	rec := &Recipe{Owner: "o", Repo: "r"}
+	releases, err := rec.FetchReleases()
+	require.NoError(t, err)
+	require.Len(t, releases, 2)
+	assert.False(t, releases[0].Prerelease, "stable release must propagate prerelease=false")
+	assert.True(t, releases[1].Prerelease, "prerelease flag from GitHub must propagate")
+}
+
+func TestFetchReleases_InfersPrereleaseFromRCTag(t *testing.T) {
+	mux := http.NewServeMux()
+	mockGithub(t, mux)
+
+	mux.HandleFunc("/repos/o/r", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{}`)
+	})
+	mux.HandleFunc("/repos/o/r/releases", func(w http.ResponseWriter, r *http.Request) {
+		// Repo forgot to set the prerelease flag, but the tags are clearly
+		// prereleases by convention. Covers both the bare "-rc1" form and
+		// the semver "-rc.1" / "-alpha.1" dotted-identifier forms.
+		fmt.Fprint(w, `[
+			{"tag_name": "v1.0.0-rc1",    "prerelease": false, "assets": []},
+			{"tag_name": "v1.0.0-rc.1",   "prerelease": false, "assets": []},
+			{"tag_name": "v1.0.0-alpha.1","prerelease": false, "assets": []}
+		]`)
+	})
+
+	rec := &Recipe{Owner: "o", Repo: "r"}
+	releases, err := rec.FetchReleases()
+	require.NoError(t, err)
+	require.Len(t, releases, 3)
+	for _, rel := range releases {
+		assert.True(t, rel.Prerelease,
+			"tag %q must be detected as a prerelease via suffix convention", rel.Version)
+	}
+}
+
+// TestFetchReleases_SemverDottedRCPropagatesEndToEnd proves a semver-style
+// dotted prerelease tag survives the full FetchReleases -> ExpandVersions
+// pipeline: it lands in the right output filename and class name, and it
+// does not become the default formula.
+func TestFetchReleases_SemverDottedRCPropagatesEndToEnd(t *testing.T) {
+	mux := http.NewServeMux()
+	mockGithub(t, mux)
+
+	mux.HandleFunc("/repos/o/tool", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{}`)
+	})
+	mux.HandleFunc("/repos/o/tool/releases", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `[
+			{"tag_name": "v1.2.0-rc.1", "prerelease": true,  "assets": []},
+			{"tag_name": "v1.1.0",      "prerelease": false, "assets": []}
+		]`)
+	})
+
+	base := &Recipe{Owner: "o", Repo: "tool"}
+	releases, err := base.FetchReleases()
+	require.NoError(t, err)
+
+	recipes := ExpandVersions(base, releases)
+	require.Len(t, recipes, 3, "2 versioned + 1 default")
+
+	// Find the rc entry by version and assert it maps to the semver-dotted
+	// filename while the class name collapses the dot (tokenWordsOnly).
+	var rc *Recipe
+	for _, r := range recipes {
+		if r.Version == "v1.2.0-rc.1" {
+			rc = r
+		}
+	}
+	require.NotNil(t, rc, "expected a recipe for v1.2.0-rc.1")
+	assert.Equal(t, "tool@1.2.0-rc.1.rb", rc.OutputFile,
+		"filename must preserve the semver dot so `brew install tool@1.2.0-rc.1` works")
+	assert.Equal(t, "ToolAT120rc1", rc.ClassName,
+		"class name strips the dot (Ruby identifier constraint) but remains unique per version")
+	assert.True(t, rc.Prerelease)
+
+	// Default points at the stable release, not the rc.
+	var def *Recipe
+	for _, r := range recipes {
+		if r.OutputFile == "tool.rb" {
+			def = r
+		}
+	}
+	require.NotNil(t, def, "a default unversioned recipe must exist for the stable release")
+	assert.Equal(t, "v1.1.0", def.Version)
+}
+
+func TestFetchReleases_SurfacesAPIError(t *testing.T) {
+	mux := http.NewServeMux()
+	mockGithub(t, mux)
+
+	mux.HandleFunc("/repos/o/r", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{}`)
+	})
+	mux.HandleFunc("/repos/o/r/releases", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "server exploded", http.StatusInternalServerError)
+	})
+
+	rec := &Recipe{Owner: "o", Repo: "r"}
+	_, err := rec.FetchReleases()
+	require.Error(t, err)
+}
+
+func TestFillFromGithub_PrefersNewestStableOverPrerelease(t *testing.T) {
+	mux := http.NewServeMux()
+	server := mockGithub(t, mux)
+
+	mux.HandleFunc("/repos/o/r", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{}`)
+	})
+	mux.HandleFunc("/repos/o/r/releases", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `[
+			{"tag_name": "v1.2.0-rc1", "prerelease": true, "assets": [
+				{"name": "tool-rc.zip", "url": "%[1]s/asset/rc", "browser_download_url": "%[1]s/dl/rc"}
+			]},
+			{"tag_name": "v1.1.0", "prerelease": false, "assets": [
+				{"name": "tool-stable.zip", "url": "%[1]s/asset/s", "browser_download_url": "%[1]s/dl/s"}
+			]}
+		]`, server.URL)
+	})
+
+	rec := &Recipe{Owner: "o", Repo: "r"}
+	require.NoError(t, rec.FillFromGithub())
+	assert.Equal(t, "v1.1.0", rec.Version,
+		"FillFromGithub must skip the prerelease and pick the newest stable")
+	require.Len(t, rec.Files, 1)
+	assert.Equal(t, "tool-stable.zip", rec.Files[0].GetName())
+}
+
+func TestFillFromGithub_FallsBackToNewestWhenOnlyPrereleases(t *testing.T) {
+	mux := http.NewServeMux()
+	mockGithub(t, mux)
+
+	mux.HandleFunc("/repos/o/r", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{}`)
+	})
+	mux.HandleFunc("/repos/o/r/releases", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `[
+			{"tag_name": "v1.0.0-rc2", "prerelease": true, "assets": []},
+			{"tag_name": "v1.0.0-rc1", "prerelease": true, "assets": []}
+		]`)
+	})
+
+	rec := &Recipe{Owner: "o", Repo: "r"}
+	require.NoError(t, rec.FillFromGithub())
+	assert.Equal(t, "v1.0.0-rc2", rec.Version,
+		"with no stable release, fall back to the newest prerelease so we still generate something")
+}
+
 func TestFillFromGithub_ReleaseListError(t *testing.T) {
 	mux := http.NewServeMux()
 	mockGithub(t, mux)

--- a/homebrew/recipe_github_test.go
+++ b/homebrew/recipe_github_test.go
@@ -260,7 +260,8 @@ func TestFetchReleases_SemverDottedRCPropagatesEndToEnd(t *testing.T) {
 	require.Len(t, recipes, 3, "2 versioned + 1 default")
 
 	// Find the rc entry by version and assert it maps to the semver-dotted
-	// filename while the class name collapses the dot (tokenWordsOnly).
+	// filename and the class name Homebrew's Formulary.class_s would derive
+	// from that filename.
 	var rc *Recipe
 	for _, r := range recipes {
 		if r.Version == "v1.2.0-rc.1" {
@@ -270,8 +271,8 @@ func TestFetchReleases_SemverDottedRCPropagatesEndToEnd(t *testing.T) {
 	require.NotNil(t, rc, "expected a recipe for v1.2.0-rc.1")
 	assert.Equal(t, "tool@1.2.0-rc.1.rb", rc.OutputFile,
 		"filename must preserve the semver dot so `brew install tool@1.2.0-rc.1` works")
-	assert.Equal(t, "ToolAT120rc1", rc.ClassName,
-		"class name strips the dot (Ruby identifier constraint) but remains unique per version")
+	assert.Equal(t, "ToolAT120Rc1", rc.ClassName,
+		"class name must match Homebrew's class_s, which uppercases the char after each separator")
 	assert.True(t, rc.Prerelease)
 
 	// Default points at the stable release, not the rc.

--- a/homebrew/recipe_template_test.go
+++ b/homebrew/recipe_template_test.go
@@ -1,0 +1,66 @@
+package homebrew
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/google/go-github/v84/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerate_UsesClassNameFromRecipe(t *testing.T) {
+	// Files is non-nil (len 0) so Generate doesn't fall back to FillFromGithub.
+	r := &Recipe{
+		Owner:       "deweysasser",
+		Repo:        "cumulus",
+		Version:     "v1.2.0-rc1",
+		Description: "A tool",
+		ClassName:   "CumulusAT120rc1",
+		Files:       []PackageFile{},
+	}
+
+	// len(Files)==0 triggers the auto-fetch branch, which we don't want in
+	// this unit test. Poke at the branch by giving Generate a non-empty slice
+	// of fake files that never get sha256'd because the template won't match
+	// them to any OS/arch filter (no "darwin"/"linux" substring).
+	r.Files = fakeFilesNoMatch()
+
+	var buf bytes.Buffer
+	require.NoError(t, r.Generate(&buf))
+
+	out := buf.String()
+	assert.True(t, strings.Contains(out, "class CumulusAT120rc1 < Formula"),
+		"rendered formula must use ClassName verbatim; got:\n%s", out)
+	assert.Contains(t, out, `version "v1.2.0-rc1"`)
+	assert.Contains(t, out, `desc "A tool"`)
+	assert.Contains(t, out, `homepage "https://github.com/deweysasser/cumulus"`)
+}
+
+func TestGenerate_DefaultFormulaClassName(t *testing.T) {
+	r := &Recipe{
+		Owner:       "o",
+		Repo:        "my-tool",
+		Version:     "v1.0.0",
+		Description: "x",
+		ClassName:   "MyTool",
+		Files:       fakeFilesNoMatch(),
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, r.Generate(&buf))
+	assert.Contains(t, buf.String(), "class MyTool < Formula")
+}
+
+// fakeFilesNoMatch returns a Files slice that is non-empty (so Generate
+// skips the auto-fetch branch) but contains no names matching the
+// darwin/linux × amd64/arm64 filter — so template rendering never calls
+// Sha256() and makes no network calls.
+func fakeFilesNoMatch() []PackageFile {
+	return []PackageFile{{
+		ReleaseAsset: &github.ReleaseAsset{
+			BrowserDownloadURL: github.Ptr("https://example.invalid/does-not-match-any-platform.txt"),
+		},
+	}}
+}

--- a/homebrew/recipe_test.go
+++ b/homebrew/recipe_test.go
@@ -71,6 +71,161 @@ func TestNewRecipe(t *testing.T) {
 	}
 }
 
+func TestVersionFilename(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"v1.2.0", "1.2.0"},
+		{"V1.2.0", "1.2.0"},
+		{"1.2.0", "1.2.0"},
+		{"v1.2.0-rc1", "1.2.0-rc1"},
+		{"v1.2.0-rc.1", "1.2.0-rc.1"},     // semver-style dotted identifier is preserved verbatim
+		{"v1.2.0-alpha.1", "1.2.0-alpha.1"},
+		{"V2", "2"},
+		{"", ""},
+		{"version-1", "ersion-1"}, // only a single leading v/V is stripped; documents the contract
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			assert.Equal(t, tt.want, versionFilename(tt.in))
+		})
+	}
+}
+
+func TestVersionedClass(t *testing.T) {
+	tests := []struct {
+		repo, version, want string
+	}{
+		{"cumulus", "v1.2.0", "CumulusAT120"},
+		{"cumulus", "1.2.0", "CumulusAT120"},
+		{"my-tool", "v1.2.0-rc1", "MyToolAT120rc1"},
+		{"some.tool", "v1.0.0", "SomeToolAT100"},
+		// Semver-style dotted prerelease identifiers — dots are stripped
+		// by tokenWordsOnly, same as any other non-alphanumeric, so "rc.1"
+		// and "rc1" both collapse to "rc1". That's intentional: the
+		// class name only needs to be a valid Ruby identifier, and the
+		// filename (which keeps the dot) is what Homebrew uses to
+		// disambiguate installs.
+		{"cumulus", "v1.2.0-rc.1", "CumulusAT120rc1"},
+		{"cumulus", "v1.2.0-alpha.1", "CumulusAT120alpha1"},
+		{"cumulus", "v1.2.0-alpha.beta", "CumulusAT120alphabeta"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.repo+"_"+tt.version, func(t *testing.T) {
+			assert.Equal(t, tt.want, versionedClass(tt.repo, tt.version))
+		})
+	}
+}
+
+func TestIsPrereleaseTag(t *testing.T) {
+	prereleases := []string{
+		// Bare suffixes and numeric-only continuations.
+		"v1.0.0-rc1",
+		"v1.0.0-rc",
+		"v1.0.0-alpha",
+		"v1.0.0-pre",
+		"1.0.0-rc1",
+		// Semver-style dotted identifiers.
+		"v1.0.0-rc.1",
+		"v1.0.0-RC.2",
+		"v1.0.0-alpha.1",
+		"v1.0.0-beta.2",
+		"v1.0.0-pre.1",
+		"v1.0.0-alpha.beta",
+		"v1.0.0-rc.0.1",
+		"v1.0.0-alpha.1.2.3",
+	}
+	stable := []string{
+		"v1.0.0",
+		"v1.0.0.1",
+		"1.2.3",
+		"v2",
+		// "-final" / "-release" are not prerelease markers by convention.
+		"v1.0.0-final",
+		"v1.0.0-release.1",
+	}
+	for _, tag := range prereleases {
+		t.Run("pre/"+tag, func(t *testing.T) {
+			assert.True(t, isPrereleaseTag(tag), "%q should be a prerelease tag", tag)
+		})
+	}
+	for _, tag := range stable {
+		t.Run("stable/"+tag, func(t *testing.T) {
+			assert.False(t, isPrereleaseTag(tag), "%q should not be a prerelease tag", tag)
+		})
+	}
+}
+
+func TestExpandVersions_MixedReleases(t *testing.T) {
+	base := &Recipe{Owner: "o", Repo: "cumulus", Description: "d"}
+	releases := []ReleaseInfo{
+		{Version: "v1.2.0-rc1", Prerelease: true},
+		{Version: "v1.1.0", Prerelease: false},
+		{Version: "v1.0.0", Prerelease: false},
+	}
+
+	out := ExpandVersions(base, releases)
+
+	require.Len(t, out, 4, "3 versioned + 1 default")
+
+	// Versioned recipes come first, in release order.
+	assert.Equal(t, "cumulus@1.2.0-rc1.rb", out[0].OutputFile)
+	assert.Equal(t, "CumulusAT120rc1", out[0].ClassName)
+	assert.Equal(t, "v1.2.0-rc1", out[0].Version)
+	assert.True(t, out[0].Prerelease)
+
+	assert.Equal(t, "cumulus@1.1.0.rb", out[1].OutputFile)
+	assert.Equal(t, "CumulusAT110", out[1].ClassName)
+	assert.False(t, out[1].Prerelease)
+
+	assert.Equal(t, "cumulus@1.0.0.rb", out[2].OutputFile)
+	assert.Equal(t, "CumulusAT100", out[2].ClassName)
+
+	// Default is the newest non-prerelease (v1.1.0, not the rc).
+	assert.Equal(t, "cumulus.rb", out[3].OutputFile)
+	assert.Equal(t, "Cumulus", out[3].ClassName)
+	assert.Equal(t, "v1.1.0", out[3].Version)
+	assert.False(t, out[3].Prerelease)
+}
+
+func TestExpandVersions_OnlyPrereleases(t *testing.T) {
+	base := &Recipe{Owner: "o", Repo: "tool"}
+	releases := []ReleaseInfo{
+		{Version: "v1.0.0-rc2", Prerelease: true},
+		{Version: "v1.0.0-rc1", Prerelease: true},
+	}
+
+	out := ExpandVersions(base, releases)
+
+	require.Len(t, out, 2, "no default when there are no stable releases")
+	for _, r := range out {
+		assert.Contains(t, r.OutputFile, "@",
+			"all outputs must be versioned when no stable exists; no bare tool.rb")
+	}
+}
+
+func TestExpandVersions_NoReleases(t *testing.T) {
+	base := &Recipe{Owner: "o", Repo: "tool"}
+	out := ExpandVersions(base, nil)
+	assert.Empty(t, out)
+}
+
+func TestExpandVersions_CopiesBaseFields(t *testing.T) {
+	base := &Recipe{Owner: "o", Repo: "tool", Description: "desc", PrivateRepo: true}
+	releases := []ReleaseInfo{
+		{Version: "v1.0.0", Prerelease: false},
+	}
+
+	out := ExpandVersions(base, releases)
+	require.Len(t, out, 2)
+	for _, r := range out {
+		assert.Equal(t, "o", r.Owner)
+		assert.Equal(t, "tool", r.Repo)
+		assert.Equal(t, "desc", r.Description)
+		assert.True(t, r.PrivateRepo)
+	}
+}
+
 func TestRecipe_Normalize(t *testing.T) {
 	type fields struct {
 	}

--- a/homebrew/recipe_test.go
+++ b/homebrew/recipe_test.go
@@ -93,22 +93,27 @@ func TestVersionFilename(t *testing.T) {
 }
 
 func TestVersionedClass(t *testing.T) {
+	// The expected values here are what Homebrew's Formulary.class_s
+	// computes from the filename stem (e.g. "cumulus@1.2.0-rc.1"). Homebrew
+	// refuses to load a formula whose class name does not match that value,
+	// so any drift from class_s is a load-time error for the end user.
 	tests := []struct {
 		repo, version, want string
 	}{
 		{"cumulus", "v1.2.0", "CumulusAT120"},
 		{"cumulus", "1.2.0", "CumulusAT120"},
-		{"my-tool", "v1.2.0-rc1", "MyToolAT120rc1"},
+		{"my-tool", "v1.2.0-rc1", "MyToolAT120Rc1"},
 		{"some.tool", "v1.0.0", "SomeToolAT100"},
-		// Semver-style dotted prerelease identifiers — dots are stripped
-		// by tokenWordsOnly, same as any other non-alphanumeric, so "rc.1"
-		// and "rc1" both collapse to "rc1". That's intentional: the
-		// class name only needs to be a valid Ruby identifier, and the
-		// filename (which keeps the dot) is what Homebrew uses to
-		// disambiguate installs.
-		{"cumulus", "v1.2.0-rc.1", "CumulusAT120rc1"},
-		{"cumulus", "v1.2.0-alpha.1", "CumulusAT120alpha1"},
-		{"cumulus", "v1.2.0-alpha.beta", "CumulusAT120alphabeta"},
+		// Semver-style dotted prerelease identifiers: every separator
+		// (dash or dot) causes the following alphanumeric to be uppercased,
+		// matching Homebrew's class_s transform.
+		{"cumulus", "v1.2.0-rc.1", "CumulusAT120Rc1"},
+		{"cumulus", "v1.2.0-alpha.1", "CumulusAT120Alpha1"},
+		{"cumulus", "v1.2.0-alpha.beta", "CumulusAT120AlphaBeta"},
+		// Regression: the exact case that failed on a user's Mac when
+		// `brew install releasetool@0.5.0-rc.1` refused to load the
+		// formula because its class name disagreed with class_s.
+		{"releasetool", "v0.5.0-rc.1", "ReleasetoolAT050Rc1"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.repo+"_"+tt.version, func(t *testing.T) {
@@ -170,7 +175,7 @@ func TestExpandVersions_MixedReleases(t *testing.T) {
 
 	// Versioned recipes come first, in release order.
 	assert.Equal(t, "cumulus@1.2.0-rc1.rb", out[0].OutputFile)
-	assert.Equal(t, "CumulusAT120rc1", out[0].ClassName)
+	assert.Equal(t, "CumulusAT120Rc1", out[0].ClassName)
 	assert.Equal(t, "v1.2.0-rc1", out[0].Version)
 	assert.True(t, out[0].Prerelease)
 

--- a/homebrew/recipe_test.go
+++ b/homebrew/recipe_test.go
@@ -79,7 +79,7 @@ func TestVersionFilename(t *testing.T) {
 		{"V1.2.0", "1.2.0"},
 		{"1.2.0", "1.2.0"},
 		{"v1.2.0-rc1", "1.2.0-rc1"},
-		{"v1.2.0-rc.1", "1.2.0-rc.1"},     // semver-style dotted identifier is preserved verbatim
+		{"v1.2.0-rc.1", "1.2.0-rc.1"}, // semver-style dotted identifier is preserved verbatim
 		{"v1.2.0-alpha.1", "1.2.0-alpha.1"},
 		{"V2", "2"},
 		{"", ""},

--- a/homebrew/template.rb
+++ b/homebrew/template.rb
@@ -1,4 +1,4 @@
-class {{.Repo | camelcase}} < Formula
+class {{.ClassName}} < Formula
 {{- if .PrivateRepo}}
   require_relative "lib/private_access"
 {{end }}

--- a/homebrew/testhelper.go
+++ b/homebrew/testhelper.go
@@ -1,0 +1,13 @@
+package homebrew
+
+import "github.com/google/go-github/v84/github"
+
+// SetNewGithubClientForTest swaps the package-level GitHub client constructor
+// used by FetchReleases / FillFromGithub and returns a restore function that
+// the caller MUST defer. Tests in other packages use this to point the code
+// at an httptest.Server. Production code should never call this.
+func SetNewGithubClientForTest(make func() *github.Client) func() {
+	orig := newGithubClient
+	newGithubClient = make
+	return func() { newGithubClient = orig }
+}

--- a/program/brew.go
+++ b/program/brew.go
@@ -65,7 +65,30 @@ func (b *Brew) Run(options *Options) error {
 		recipes = append(recipes, &r)
 	}
 
-	err := parallel[*homebrew.Recipe](recipes, func(r *homebrew.Recipe) error {
+	// Expand each configured recipe into (N versioned + optional default)
+	// output recipes — one .rb file per release plus the default unversioned
+	// formula pointing at the newest non-prerelease.
+	var expanded []*homebrew.Recipe
+	var defaults []*homebrew.Recipe
+	for _, base := range recipes {
+		base.Normalize()
+		releases, err := base.FetchReleases()
+		if err != nil {
+			return err
+		}
+		subs := homebrew.ExpandVersions(base, releases)
+		if len(subs) == 0 {
+			return fmt.Errorf("no release found for %s/%s", base.Owner, base.Repo)
+		}
+		expanded = append(expanded, subs...)
+		for _, s := range subs {
+			if !strings.Contains(s.OutputFile, "@") {
+				defaults = append(defaults, s)
+			}
+		}
+	}
+
+	err := parallel[*homebrew.Recipe](expanded, func(r *homebrew.Recipe) error {
 
 		generated, err := b.HandleRecipe(r)
 		if generated {
@@ -89,7 +112,7 @@ func (b *Brew) Run(options *Options) error {
 
 	if configFile != nil {
 		for _, f := range configFile.Docs {
-			if err := f.Update(configFile, recipes); err != nil {
+			if err := f.Update(configFile, defaults); err != nil {
 				return err
 			}
 		}
@@ -103,18 +126,22 @@ func (b *Brew) HandleRecipe(r *homebrew.Recipe) (bool, error) {
 		Str("owner", r.Owner).
 		Str("repo", r.Repo).
 		Str("desc", r.Description).
+		Str("version", r.Version).
+		Str("output", r.OutputFile).
 		Logger()
 
 	log.Debug().Msg("Handling recipe")
 
-	out := r.Repo + ".rb"
-
-	err := r.FillFromGithub()
-	if err != nil {
-		return false, err
-	}
+	out := r.OutputFile
+	versioned := strings.Contains(out, "@")
 
 	if _, err := os.Stat(out); err == nil {
+		if versioned {
+			// Versioned formulas are immutable once written — a given
+			// (repo, version) always produces the same content.
+			log.Debug().Msg("Versioned formula exists; skipping")
+			return false, nil
+		}
 		log.Debug().Msg("Existing output file")
 		current, err := homebrew.ParseRecipeFile(out)
 		if err != nil {

--- a/program/brew_test.go
+++ b/program/brew_test.go
@@ -92,7 +92,7 @@ func TestBrew_Run_GeneratesDefaultAndVersionedFormulas(t *testing.T) {
 
 	// Versioned RC formula content.
 	rcBody := readAll(t, filepath.Join(dir, "cumulus@1.2.0-rc1.rb"))
-	assert.Contains(t, rcBody, "class CumulusAT120rc1 < Formula")
+	assert.Contains(t, rcBody, "class CumulusAT120Rc1 < Formula")
 	assert.Contains(t, rcBody, `version "v1.2.0-rc1"`)
 
 	// Stable versioned.

--- a/program/brew_test.go
+++ b/program/brew_test.go
@@ -1,0 +1,161 @@
+package program
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/deweysasser/releasetool/homebrew"
+	"github.com/google/go-github/v84/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newMockGithub stands up an httptest.Server and swaps the homebrew package's
+// GitHub client constructor so Brew.Run talks to the mock. Cleanup restores
+// the original on test exit.
+func newMockGithub(t *testing.T, handler http.Handler) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	restore := homebrew.SetNewGithubClientForTest(func() *github.Client {
+		c := github.NewClient(nil)
+		u, err := url.Parse(server.URL + "/")
+		require.NoError(t, err)
+		c.BaseURL = u
+		c.UploadURL = u
+		return c
+	})
+	t.Cleanup(restore)
+	return server
+}
+
+// TestBrew_Run_GeneratesDefaultAndVersionedFormulas drives the full Brew.Run
+// flow against a mocked GitHub with 3 releases (2 stable + 1 rc) and asserts
+// the set of output files and their contents. A re-run is then verified to
+// be a no-op.
+func TestBrew_Run_GeneratesDefaultAndVersionedFormulas(t *testing.T) {
+	mux := http.NewServeMux()
+	server := newMockGithub(t, mux)
+
+	mux.HandleFunc("/repos/deweysasser/cumulus", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"description": "A better AWS CLI", "private": false}`)
+	})
+	// All three releases on a single page; no assets so no SHA256 downloads
+	// are triggered during template rendering.
+	mux.HandleFunc("/repos/deweysasser/cumulus/releases", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `[
+			{"tag_name": "v1.2.0-rc1", "prerelease": true,  "assets": []},
+			{"tag_name": "v1.2.0",     "prerelease": false, "assets": []},
+			{"tag_name": "v1.1.0",     "prerelease": false, "assets": []}
+		]`)
+		_ = server // keep reference to avoid unused-var churn if the signature shifts
+	})
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	b := &Brew{Repo: []string{"deweysasser/cumulus"}}
+	require.NoError(t, b.Run(&Options{}))
+
+	// Expect 4 formulas: 3 versioned + 1 default.
+	want := []string{
+		"cumulus.rb",
+		"cumulus@1.2.0.rb",
+		"cumulus@1.1.0.rb",
+		"cumulus@1.2.0-rc1.rb",
+	}
+	for _, name := range want {
+		info, err := os.Stat(filepath.Join(dir, name))
+		require.NoError(t, err, "missing %s", name)
+		assert.False(t, info.IsDir())
+	}
+
+	// No stray .tmp files left behind.
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		assert.False(t, strings.HasSuffix(e.Name(), ".tmp"),
+			"stale tmp file left behind: %s", e.Name())
+	}
+
+	// Default formula content: newest STABLE, not the RC.
+	defaultBody := readAll(t, filepath.Join(dir, "cumulus.rb"))
+	assert.Contains(t, defaultBody, "class Cumulus < Formula")
+	assert.Contains(t, defaultBody, `version "v1.2.0"`)
+
+	// Versioned RC formula content.
+	rcBody := readAll(t, filepath.Join(dir, "cumulus@1.2.0-rc1.rb"))
+	assert.Contains(t, rcBody, "class CumulusAT120rc1 < Formula")
+	assert.Contains(t, rcBody, `version "v1.2.0-rc1"`)
+
+	// Stable versioned.
+	stableBody := readAll(t, filepath.Join(dir, "cumulus@1.2.0.rb"))
+	assert.Contains(t, stableBody, "class CumulusAT120 < Formula")
+
+	// Re-run: should be a complete no-op — existing files untouched.
+	statBefore := statAll(t, dir, want)
+	require.NoError(t, b.Run(&Options{}))
+	statAfter := statAll(t, dir, want)
+	for i, name := range want {
+		assert.Equal(t, statBefore[i].ModTime(), statAfter[i].ModTime(),
+			"file %s was rewritten on a re-run but should be immutable/stable", name)
+	}
+}
+
+// TestBrew_Run_SkipsDefaultWhenOnlyPrereleases verifies that a repo with only
+// prerelease tags produces only versioned formulas — no default unversioned
+// file is written.
+func TestBrew_Run_SkipsDefaultWhenOnlyPrereleases(t *testing.T) {
+	mux := http.NewServeMux()
+	newMockGithub(t, mux)
+
+	mux.HandleFunc("/repos/o/tool", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{}`)
+	})
+	mux.HandleFunc("/repos/o/tool/releases", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `[
+			{"tag_name": "v1.0.0-rc2", "prerelease": true, "assets": []},
+			{"tag_name": "v1.0.0-rc1", "prerelease": true, "assets": []}
+		]`)
+	})
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	b := &Brew{Repo: []string{"o/tool"}}
+	require.NoError(t, b.Run(&Options{}))
+
+	_, err := os.Stat(filepath.Join(dir, "tool.rb"))
+	assert.True(t, os.IsNotExist(err),
+		"default tool.rb must NOT be written when the repo has only prereleases")
+
+	for _, name := range []string{"tool@1.0.0-rc1.rb", "tool@1.0.0-rc2.rb"} {
+		_, err := os.Stat(filepath.Join(dir, name))
+		assert.NoError(t, err, "missing versioned prerelease file: %s", name)
+	}
+}
+
+func readAll(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return string(b)
+}
+
+func statAll(t *testing.T, dir string, names []string) []os.FileInfo {
+	t.Helper()
+	out := make([]os.FileInfo, len(names))
+	for i, n := range names {
+		info, err := os.Stat(filepath.Join(dir, n))
+		require.NoError(t, err)
+		out[i] = info
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

- Paginate `ListReleases` and emit one `{repo}@{version}.rb` formula per GitHub release, plus a default `{repo}.rb` pointing at the newest non-prerelease. Tap users can install any historical version or opt into an `-rc` build without changing the default install.
- Prerelease detection uses GitHub's `prerelease` flag as authoritative; as a safety net, tags matching `-rc`, `-alpha`, `-beta`, or `-pre` (both bare like `-rc1` and semver-dotted like `-rc.1` / `-alpha.1.2`) are treated as prereleases even when the flag is unset.
- Versioned formulas are immutable — re-runs skip existing `@`-versioned files unconditionally. The default file still uses the existing version-compare skip logic.

## Implementation notes

- `homebrew/recipe.go`: new `FetchReleases`/`ReleaseInfo`, new `ExpandVersions`, new `Recipe` fields (`ClassName`, `OutputFile`, `Prerelease`), and small helpers (`versionFilename`, `versionedClass`, `isPrereleaseTag`). `FillFromGithub` now delegates to `FetchReleases` and picks the newest non-prerelease (falling back to newest overall when only prereleases exist).
- `homebrew/template.rb`: one-line change to render `class {{.ClassName}}` instead of `class {{.Repo | camelcase}}`.
- `program/brew.go`: `Brew.Run` expands recipes before the parallel processor; `UpdateDoc` receives defaults only so docs stay one line per tool.
- `homebrew/testhelper.go`: tiny exported `SetNewGithubClientForTest` hook so the program-package integration test can share the httptest-based mock pattern.

## Test plan

- [x] `go test -race ./...` — full suite passes (existing + new)
- [x] `go vet ./...` — clean
- [x] `make compile` — binary builds
- [x] New unit coverage: `TestVersionFilename`, `TestVersionedClass`, `TestIsPrereleaseTag` (including semver-dotted forms like `-rc.1`, `-alpha.beta`, `-alpha.1.2.3`), `TestExpandVersions_*` (4 cases)
- [x] New mock-GitHub coverage: `TestFetchReleases_PaginatesAllPages` (with `Link: rel="next"`), `_ReturnsPrereleaseFlag`, `_InfersPrereleaseFromRCTag`, `_SemverDottedRCPropagatesEndToEnd`, `_SurfacesAPIError`; `TestFillFromGithub_PrefersNewestStableOverPrerelease`, `_FallsBackToNewestWhenOnlyPrereleases`
- [x] New template coverage: `TestGenerate_UsesClassNameFromRecipe`, `TestGenerate_DefaultFormulaClassName`
- [x] New integration coverage: `TestBrew_Run_GeneratesDefaultAndVersionedFormulas` (asserts the full file set + re-run is a no-op), `TestBrew_Run_SkipsDefaultWhenOnlyPrereleases`
- [ ] Smoke against a real repo with mixed release history (`releasetool brew deweysasser/<repo>` → inspect generated files)
- [ ] `brew install --build-from-source` one default and one versioned file on macOS/Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)